### PR TITLE
Add infrastructure to run clang-tidy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,3 +50,5 @@ build:ubsan --linkopt -fsanitize=undefined
 #   bazel ... --config clang-tiday
 build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
 build:clang-tidy --output_groups=report
+# Actually use ./.clang-tidy.
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config

--- a/.bazelrc
+++ b/.bazelrc
@@ -8,5 +8,45 @@ common --registry https://raw.githubusercontent.com/bazelboost/registry/main
 # explicitly so it needs to be added back explicitly).
 common --registry https://bcr.bazel.build/
 
+# Arguments for C++ builds.
+# All warnings are switched on and generate errors.
+# TODO does this work on Windows?
 build --cxxopt=-std=c++17
 build --cxxopt=-Werror
+build --cxxopt=-Wall
+
+# Configuration for builds with address sanitiser.
+# This can be selected with
+#   bazel ... --config asan
+build:asan --strip=never
+# Options: https://github.com/google/sanitizers/wiki/AddressSanitizer
+build:asan --copt -fsanitize=address
+build:asan --linkopt -fsanitize=address
+# If this is too slow, -O1 may be a good tradeoff.
+build:asan --copt -O0
+# Nicer stack traces
+build:asan --copt -fno-omit-frame-pointer
+
+# Configuration for builds with memory sanitizer.
+# This can be selected with
+#   bazel ... --config msan
+build:msan --strip=never
+build:msan --force_pic
+# https://github.com/google/sanitizers/wiki/MemorySanitizer
+build:msan --copt -fsanitize=memory
+build:msan --linkopt -fsanitize=memory
+# The memory sanitizer docs say -O2 but that seems excessive.
+build:asan --copt -O1
+build:msan --copt -fno-omit-frame-pointer
+
+# Configuration for builds with the Undefined Behavior Sanitizer.
+# This can be selected with
+#   bazel ... --config ubsan
+build:ubsan --copt -fsanitize=undefined
+build:ubsan --linkopt -fsanitize=undefined
+
+# Configuration for "builds" with clang-tidy, which looks for errors.
+# This can be selected with
+#   bazel ... --config clang-tiday
+build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --output_groups=report

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,25 +1,31 @@
 UseColor: true
 
 # Cast the net wide: select all checks that are not obviously irrelevant.
+# Do not use comments in the middle of the list.
 Checks: >
-    abseil-*, # Checks related to Abseil library.
-    boost-*, # Checks related to Boost library.
-    bugprone-*, # Checks that target bug-prone code constructs.
-    cert-*, # Checks related to CERT Secure Coding Guidelines.
-    clang-analyzer-*, # Clang Static Analyzer checks.
-    concurrency-*, # Checks related to concurrent programming.
-    cppcoreguidelines-*, # Checks related to C++ Core Guidelines.
-    google-*, # Checks related to Google coding conventions.
-    hicpp-*, # Checks related to High Integrity C++ Coding Standard.
-    linuxkernel-*, # Checks related to the Linux Kernel coding conventions.
-    llvm-*, # Checks related to the LLVM coding conventions.
-    llvmlibc-*, # Checks related to the LLVM-libc coding standards.
-    misc-*, # Miscellaneous checks.
-    modernize-*, # Checks that advocate usage of modern language constructs.
-    mpi-*, # Checks related to MPI (Message Passing Interface).
-    performance-*, # Checks that target performance-related issues.
-    portability-*, # Checks that target portability-related issues.
-    readability-*, # Checks that target readability-related issues.
+    abseil-*,
+    boost-*,
+    bugprone-*,
+    cert-*,
+    clang-analyzer-*,
+    concurrency-*,
+    cppcoreguidelines-*,
+    google-*,
+    hicpp-*,
+    linuxkernel-*,
+    llvm-*,
+    misc-*,
+    modernize-*,
+    mpi-*,
+    performance-*,
+    portability-*,
+    readability-*,
+    -modernize-use-trailing-return-type,
+    -llvm-header-guard,
+    -misc-include-cleaner,
+
+ExtraArgs:
+    - -Wno-pragma-once-outside-header
 
 # TODO add info on how to ignore errors.
 WarningsAsErrors: "*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,25 @@
+UseColor: true
+
+# Cast the net wide: select all checks that are not obviously irrelevant.
+Checks: >
+    abseil-*, # Checks related to Abseil library.
+    boost-*, # Checks related to Boost library.
+    bugprone-*, # Checks that target bug-prone code constructs.
+    cert-*, # Checks related to CERT Secure Coding Guidelines.
+    clang-analyzer-*, # Clang Static Analyzer checks.
+    concurrency-*, # Checks related to concurrent programming.
+    cppcoreguidelines-*, # Checks related to C++ Core Guidelines.
+    google-*, # Checks related to Google coding conventions.
+    hicpp-*, # Checks related to High Integrity C++ Coding Standard.
+    linuxkernel-*, # Checks related to the Linux Kernel coding conventions.
+    llvm-*, # Checks related to the LLVM coding conventions.
+    llvmlibc-*, # Checks related to the LLVM-libc coding standards.
+    misc-*, # Miscellaneous checks.
+    modernize-*, # Checks that advocate usage of modern language constructs.
+    mpi-*, # Checks related to MPI (Message Passing Interface).
+    performance-*, # Checks that target performance-related issues.
+    portability-*, # Checks that target portability-related issues.
+    readability-*, # Checks that target readability-related issues.
+
+# TODO add info on how to ignore errors.
+WarningsAsErrors: "*"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches: [ main, develop, test-github-actions ]
+  pull_request:
+    branches: [ main, develop, test-github-actions ]
+
+  workflow_dispatch:
+
+jobs:
+  test:
+    # clang-tidy might behave slightly differently on difference operating
+    # systems, but hopefully using a recent Ubuntu will make it cover a fair
+    # amount.
+    runs-on: ubuntu-22.04
+        
+    steps:
+    - uses: actions/checkout@v4
+    - uses: bazel-contrib/setup-bazel@0.8.1
+      with:
+        # Avoid downloading Bazel every time.
+        bazelisk-cache: true
+        # Store build cache per workflow.
+        disk-cache: ${{ github.workflow }}
+        # Share repository cache between workflows.
+        repository-cache: true
+    - run: bazel build //... config clang-tidy

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -23,4 +23,4 @@ jobs:
         disk-cache: ${{ github.workflow }}
         # Share repository cache between workflows.
         repository-cache: true
-    - run: bazel build //... config clang-tidy
+    - run: bazel build //... --config clang-tidy

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,3 +8,10 @@ cc_library(
         "@boost.rational//:boost.rational",
     ]
 )
+
+# Use .clang-tidy when "clang_tidy_config" is requested.
+filegroup(
+    name = "clang_tidy_config",
+    srcs = [".clang-tidy"],
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,3 +10,17 @@ bazel_dep(name = "boost.rational", version = "1.83.0.bzl.1")
 # Test frameworks that can be used:
 bazel_dep(name = "googletest", version = "1.14.0")
 bazel_dep(name = "boost.test", version = "1.83.0.bzl.4")
+
+# Run clang-tidy, with `bazel ... --config clang-tidy`.
+# clang-tidy requires access to included files, so it is most useful to treat
+# it, effectively, as a compiler.
+
+# (2024) The "bazel_clang_tidy" repository does not seem to be very actively
+# maintained, but it does do the job.
+# Except that there does not seem to be a bzlmod registry that has it.
+# So give the Git source explicitly:
+bazel_dep(name = "bazel_clang_tidy", version = "")
+git_override(
+    module_name="bazel_clang_tidy",
+    remote="https://github.com/erenon/bazel_clang_tidy.git",
+    commit='bff5c59c843221b05ef0e37cef089ecc9d24e7da')


### PR DESCRIPTION
`clang-tidy` needs similar information to builds. This therefore runs `clang-tidy` under Bazel.

This also adds a GitHub workflow that runs `clang-tidy`. It should probably fail at first.