### PR TITLE
Fix suggestions from clang-tidy

### DIFF
--- a/include/compute/add_two.hpp
+++ b/include/compute/add_two.hpp
@@ -7,9 +7,11 @@ namespace compute
 
     class AddTwo {
     public:
-        int operator() (int i) const {
-            boost::rational<int> fraction(10, 5);
-            return i + fraction.numerator();
+        int operator() (int value) const {
+            const int numerator = 10;
+            const int denominator =5;
+            const boost::rational<int> fraction(numerator, denominator);
+            return value + fraction.numerator();
         }
     };
 

--- a/test/test_add_two.cpp
+++ b/test/test_add_two.cpp
@@ -3,6 +3,6 @@
 #include <gtest/gtest.h>
 
 TEST(AddTwo, Fifty) {
-    compute::AddTwo add_two;
+    const compute::AddTwo add_two;
     EXPECT_EQ(add_two(50), 52);
 }

--- a/test/test_add_two_2.cpp
+++ b/test/test_add_two_2.cpp
@@ -6,6 +6,6 @@
 
 BOOST_AUTO_TEST_CASE (AddTwo)
 {
-    compute::AddTwo add_two;
+    const compute::AddTwo add_two;
     BOOST_TEST(add_two(70) == 72);
 }


### PR DESCRIPTION
The introduction of `clang-tidy`, and the failure for tests to pass, is happening in #5.